### PR TITLE
✅Update test IG to pass new validation rule

### DIFF
--- a/tests/data/site_root/input/ignoreWarnings.txt
+++ b/tests/data/site_root/input/ignoreWarnings.txt
@@ -1,0 +1,7 @@
+== Suppressed Messages ==
+
+# Add warning and/or information messages here after you've confirmed that they aren't really a problem
+# (And include comments like this justifying why)
+
+# Example
+# WARNING: StructureDefinition/myObservation: StructureDefinition.snapshot.element[15].mapping[3].map: value should not start or finish with whitespace


### PR DESCRIPTION
The latest IG publisher seems to require a certain format for the suppress warnings file in the IG.
See https://confluence.hl7.org/display/FHIR/Implementation+Guide+Parameters for details. 