### PR TITLE
🐛 Fix location of default site_root

### DIFF
--- a/ncpi_fhir_utility/config.py
+++ b/ncpi_fhir_utility/config.py
@@ -61,7 +61,7 @@ RESOURCE_SUBMISSION_ORDER = [
 ]
 
 ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
-DEFAULT_SITE_ROOT = os.path.join(ROOT_DIR, "site_root")
+DEFAULT_SITE_ROOT = os.path.join(os.getcwd(), "site_root")
 DEFAULT_IG_CONTROL_FILE = os.path.join(DEFAULT_SITE_ROOT, "ig.ini")
 SCRIPTS_DIR = os.path.join(ROOT_DIR, "scripts")
 RUN_IG_PUBLISHER_SCRIPT = "run_publisher.sh"


### PR DESCRIPTION
Default site_root was pointing to a location inside the place where `ncpi-fhir-utility` is installed rather than the current working directory:

```
➜  ncpi-model-forge git:(add-patient-species) ✗ fhirutil add site_root/input/resources                                                                                     [venv]
Usage: fhirutil add [OPTIONS] DATA_PATH
Try "fhirutil add -h" for help.

Error: Invalid value for "--ig_control_file": File "/Users/singhn4/Projects/fhir-sci/sandbox/ncpi-model-forge/venv/lib/python3.7/site-packages/site_root/ig.ini" does not exist
```