### PR TITLE
✨ Add headers to result object to support results from bulk export

### DIFF
--- a/ncpi_fhir_utility/client.py
+++ b/ncpi_fhir_utility/client.py
@@ -185,7 +185,8 @@ class FhirApiClient(object):
 
             {
                 'status_code': response.status_code,
-                'response': response.json() or response.text
+                'response': response.json() or response.text,
+                'response_headers': response.headers,
             }
 
         :param request_method_name: requests method name
@@ -240,6 +241,7 @@ class FhirApiClient(object):
                 "status_code": response.status_code,
                 "request_url": request_url,
                 "response": resp_content,
+                "response_headers": response.headers,
             },
         )
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -87,7 +87,8 @@ def test_ig_validation(temp_site_root, dir_list, expected_code):
 
     # Run version update
     result = runner.invoke(
-        cli.update_versions, ["1.0.0", "--site_root", temp_site_root],
+        cli.update_versions,
+        ["1.0.0", "--site_root", temp_site_root],
     )
     assert result.exit_code == 0
 
@@ -102,11 +103,13 @@ def test_ig_validation(temp_site_root, dir_list, expected_code):
 def test_version_update_error(temp_site_root):
     runner = CliRunner()
     result = runner.invoke(
-        cli.update_versions, ["1.0.0", "--site_root", temp_site_root],
+        cli.update_versions,
+        ["1.0.0", "--site_root", temp_site_root],
     )
     assert result.exit_code == 0
     result = runner.invoke(
-        cli.update_versions, ["1.0.0", "--site_root", "fake"],
+        cli.update_versions,
+        ["1.0.0", "--site_root", "fake"],
     )
     assert result.exit_code > 0
 


### PR DESCRIPTION
The when GETting FHIR Bulk export, the status and final output of the asynchronous call is returned by way 'Content-Location' in the response header. This provides the necessary headers under the key, "response_headers", in the result object that is returned. 