### PR TITLE
⬆️ Let click be more recent than 7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-click==7.0
+click>=7.0,<8.1
 python-dotenv==0.10.3
 requests==2.22.0


### PR DESCRIPTION
closes #32 
Still don't go past 8.1 though. We can test and revisit later.