### PR TITLE
Support OAuth authentication for publishing IG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+#IDEA
+.idea

--- a/ncpi_fhir_utility/cli.py
+++ b/ncpi_fhir_utility/cli.py
@@ -48,6 +48,12 @@ def cli():
 @cli.command()
 @click.option("--password", "pw", help="Client secret or user password")
 @click.option("--username", "user", help="Client id or username")
+@click.option("--oauth-url", "oauth_url", help="URL of token endpoint for OAuth authentication")
+@click.option("--oauth-client-id", "oauth_client_id", help="Client ID for OAuth authentication")
+@click.option("--oauth-client-secret", "oauth_client_secret", help="Client secret for OAuth authentication")
+@click.option("--oauth-uma-audience", "oauth_uma_audience", help="Audience parameter to use to fetch UMA ticket. If "
+                                                                  "not present, a standard access token will be used "
+                                                                  "as bearer token")
 @click.option(
     "--base_url",
     type=str,
@@ -59,7 +65,7 @@ def cli():
     "resource_file_or_dir",
     type=click.Path(exists=True, file_okay=True, dir_okay=True),
 )
-def publish(resource_file_or_dir, base_url, user, pw):
+def publish(resource_file_or_dir, base_url, user, pw, oauth_url, oauth_client_id, oauth_client_secret, oauth_uma_audience):
     """
     Push FHIR model files to FHIR server. Default use of this method is to
     push FHIR model files to the Simplifier FHIR server configured in
@@ -72,7 +78,7 @@ def publish(resource_file_or_dir, base_url, user, pw):
             'publish to the Simplifier project
     """
     m = "Publish"
-    do(m, app.publish_to_server, resource_file_or_dir, base_url, user, pw)
+    do(m, app.publish_to_server, resource_file_or_dir, base_url, user, pw, oauth_url, oauth_client_id, oauth_client_secret, oauth_uma_audience)
 
 
 @click.command()

--- a/ncpi_fhir_utility/client.py
+++ b/ncpi_fhir_utility/client.py
@@ -56,7 +56,7 @@ class FhirApiClient(object):
         :param endpoint: Optional FHIR endpoint to use for all requests
         :type endpoint: str
         :param auth: basic auth parameters
-        :type auth: requests.auth.HTTPBasicAuth object
+        :type auth: requests.auth.AuthBase object
 
         :returns: a tuple (success boolean, result dict) See send_request
         for details.

--- a/ncpi_fhir_utility/oauth.py
+++ b/ncpi_fhir_utility/oauth.py
@@ -1,0 +1,52 @@
+import logging
+from datetime import datetime
+
+import requests
+from requests.auth import AuthBase
+import datetime
+
+logger = logging.getLogger(__name__)
+
+
+class OAuth(AuthBase):
+    access_token: str
+    expiration: datetime
+
+    def __init__(self, url, client_id, client_secret, uma_audience):
+        self.url = url
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.uma_audience = uma_audience
+        self.refresh_token()
+
+    def __call__(self, r):
+        if self.expiration <= datetime.datetime.now():
+            self.refresh_token()
+        r.headers["authorization"] = "Bearer " + self.access_token
+        return r
+
+    def refresh_token(self):
+        token = self.get_access_token()
+        self.access_token = token['access_token']
+        self.expiration = datetime.datetime.now() + datetime.timedelta(seconds=(token['expires_in'] - 10))
+
+    def get_access_token(self):
+        response_access_token = requests.post(
+            self.url,
+            data={'grant_type': 'client_credentials', 'client_id': self.client_id, 'client_secret': self.client_secret}
+        )
+
+        response_access_token.raise_for_status()
+
+        if not self.uma_audience:
+            return response_access_token.json()
+        else:
+            response = requests.post(
+                self.url,
+                headers={'Authorization': f"Bearer {response_access_token.json()['access_token']}"},
+                data={'grant_type': 'urn:ietf:params:oauth:grant-type:uma-ticket',
+                      'audience': self.uma_audience}
+            )
+
+            response.raise_for_status()
+            return response.json()

--- a/ncpi_fhir_utility/utils.py
+++ b/ncpi_fhir_utility/utils.py
@@ -118,6 +118,10 @@ def requests_retry_session(
     """
     session = session or requests.Session()
 
+    caCert = os.getenv('CONFIG__REQUESTS__CA')
+    if caCert:
+        session.verify = caCert
+
     retry = Retry(
         total=total,
         read=read,


### PR DESCRIPTION
With this PR, fhirutil CLI supports oauth authentication for publishing an implementation guide. There is 4 new options for publish command :
- oauth-url: URL of OAuth token endpoint
- oauth-client-id: id of the client to use to authenticate
- oauth-client-secret: corresponding secret
- oauth-uma-audience: (Optional) audience to use in case fhir server need a Request Party Token (RPT)

Example:
```
❯ fhirutil publish --base_url http://localhost:8080/fhir \
          --oauth-url https://localhost:8180/auth/realms/myrealm/protocol/openid-connect/token \
          --oauth-client-id my_client_id \
          --oauth-client-secret my_secret site_root/input/resources/search
```